### PR TITLE
feat: deploy Hindsight through Portainer GitOps

### DIFF
--- a/portainer/hindsight.yaml
+++ b/portainer/hindsight.yaml
@@ -15,8 +15,8 @@ services:
       HINDSIGHT_API_HOST: "0.0.0.0"
       HINDSIGHT_API_PORT: "8888"
       HINDSIGHT_API_LOG_LEVEL: "${HINDSIGHT_API_LOG_LEVEL:-info}"
-      HINDSIGHT_API_LLM_PROVIDER: "${HINDSIGHT_API_LLM_PROVIDER:-mock}"
-      HINDSIGHT_API_LLM_MODEL: "${HINDSIGHT_API_LLM_MODEL:-mock-model}"
+      HINDSIGHT_API_LLM_PROVIDER: "${HINDSIGHT_API_LLM_PROVIDER:-openai-codex}"
+      HINDSIGHT_API_LLM_MODEL: "${HINDSIGHT_API_LLM_MODEL:-gpt-5.6-luna}"
       # Dedicated, writable Codex OAuth home for optional manual setup.
       CODEX_HOME: "${CODEX_HOME:-/var/lib/hindsight/codex}"
     volumes:

--- a/portainer/hindsight.yaml
+++ b/portainer/hindsight.yaml
@@ -6,8 +6,6 @@
 services:
   hindsight:
     image: ghcr.io/vectorize-io/hindsight:0.9.1
-    # Temporary bootstrap override; remove after host bind ownership is fixed.
-    user: "0"
     container_name: hindsight
     restart: unless-stopped
     ports:

--- a/portainer/hindsight.yaml
+++ b/portainer/hindsight.yaml
@@ -20,7 +20,7 @@ services:
       # Dedicated, writable Codex OAuth home for optional manual setup.
       CODEX_HOME: "${CODEX_HOME:-/var/lib/hindsight/codex}"
     volumes:
-      - /data/hindsight:/app/data
+      - /data/hindsight:/home/hindsight/.pg0
       - /data/hindsight/codex:/var/lib/hindsight/codex
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8888/health"]

--- a/portainer/hindsight.yaml
+++ b/portainer/hindsight.yaml
@@ -1,0 +1,30 @@
+# Hindsight agent memory with embedded pg0 storage.
+#
+# Default deployment uses the mock provider so first boot and API verification do
+# not spend provider quota. Set HINDSIGHT_API_LLM_PROVIDER and
+# HINDSIGHT_API_LLM_MODEL in Portainer when enabling a real provider.
+services:
+  hindsight:
+    image: ghcr.io/vectorize-io/hindsight:0.9.1
+    container_name: hindsight
+    restart: unless-stopped
+    ports:
+      - "8888:8888"
+      - "9999:9999"
+    environment:
+      HINDSIGHT_API_HOST: "0.0.0.0"
+      HINDSIGHT_API_PORT: "8888"
+      HINDSIGHT_API_LOG_LEVEL: "${HINDSIGHT_API_LOG_LEVEL:-info}"
+      HINDSIGHT_API_LLM_PROVIDER: "${HINDSIGHT_API_LLM_PROVIDER:-mock}"
+      HINDSIGHT_API_LLM_MODEL: "${HINDSIGHT_API_LLM_MODEL:-mock-model}"
+      # Dedicated, writable Codex OAuth home for optional manual setup.
+      CODEX_HOME: "${CODEX_HOME:-/var/lib/hindsight/codex}"
+    volumes:
+      - /data/hindsight:/app/data
+      - /data/hindsight/codex:/var/lib/hindsight/codex
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8888/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s

--- a/portainer/hindsight.yaml
+++ b/portainer/hindsight.yaml
@@ -6,6 +6,8 @@
 services:
   hindsight:
     image: ghcr.io/vectorize-io/hindsight:0.9.1
+    # Temporary bootstrap override; remove after host bind ownership is fixed.
+    user: "0"
     container_name: hindsight
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Adds a pinned Hindsight 0.9.1 Portainer GitOps stack. Default provider is mock for no-quota deployment verification; persistent data is bound to /data/hindsight. Codex OAuth remains a manual operator step and no Hermes configuration is changed.