### PR TITLE
feat: collect Beelink metrics with cAdvisor

### DIFF
--- a/portainer/monitoring.md
+++ b/portainer/monitoring.md
@@ -1,0 +1,59 @@
+# Monitoring stack
+
+`monitoring.yaml` runs Grafana, VictoriaMetrics, Loki, and the Beelink host collector.
+The collector path is:
+
+```text
+cAdvisor -> vmagent -> VictoriaMetrics <- Grafana
+```
+
+## Deployment inputs
+
+The Portainer stack uses the Git repository's `portainer/monitoring.yaml` file. The
+scrape configuration is versioned next to it at
+`portainer/vmagent/prometheus.yml` and is loaded through the Compose `configs`
+entry; no host-side configuration file is required.
+
+Set the existing Grafana secret before deploying or updating the stack:
+
+```text
+GF_SECURITY_ADMIN_PASSWORD=<value>
+```
+
+The stack creates or uses these host directories for persistent data:
+
+- `/data/grafana`
+- `/data/victoriametrics`
+- `/data/loki`
+- `/data/vmagent`
+
+The Docker host running Portainer (the Beelink) must allow the cAdvisor mounts in
+`monitoring.yaml`. They are read-only except for vmagent's local retry buffer and
+the existing service data directories. The Docker socket is mounted read-only;
+cAdvisor and vmagent are not exposed on host ports.
+
+## Metrics
+
+The `beelink-cadvisor` scrape job targets `cadvisor:8080` on the private
+`monitoring_monitoring` network and adds the stable labels `host="beelink"` and
+`service="cadvisor"`. vmagent forwards the Prometheus-format metrics to
+`http://victoriametrics:8428/api/v1/write` and buffers unsent samples under
+`/data/vmagent` while VictoriaMetrics is unavailable.
+
+cAdvisor supplies both Docker container statistics and machine/filesystem
+metrics from the Beelink. A separate node-exporter is intentionally not included:
+the current stack has no host-exporter convention, and cAdvisor covers the host
+and container metrics required here without another privileged collector.
+
+## Verification
+
+After the stack is running, verify the collector path from the host or Portainer:
+
+1. Check that `cadvisor`, `vmagent`, and `victoriametrics` are running.
+2. From the monitoring network, confirm cAdvisor responds at `http://cadvisor:8080/metrics`.
+3. Confirm vmagent's target for job `beelink-cadvisor` is up and its remote-write queue is healthy.
+4. Query VictoriaMetrics for a non-empty host series, for example
+   `machine_memory_bytes{host="beelink"}`, and a container series such as
+   `container_cpu_usage_seconds_total{host="beelink"}`.
+5. Redeploy or restart the stack and repeat the checks; `/data/victoriametrics`
+   and `/data/vmagent` must remain intact.

--- a/portainer/monitoring.yaml
+++ b/portainer/monitoring.yaml
@@ -30,6 +30,42 @@ services:
     networks:
       - monitoring
 
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    container_name: cadvisor
+    restart: unless-stopped
+    command:
+      - --housekeeping_interval=15s
+    volumes:
+      # Read-only host views required for machine and container metrics.
+      - /:/rootfs:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      # cAdvisor needs Docker metadata; it never writes to the socket.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /dev/disk:/dev/disk:ro
+    networks:
+      - monitoring
+
+  vmagent:
+    image: victoriametrics/vmagent:latest
+    container_name: vmagent
+    restart: unless-stopped
+    command:
+      - -promscrape.config=/etc/vmagent/prometheus.yml
+      - -remoteWrite.url=http://victoriametrics:8428/api/v1/write
+      - -remoteWrite.tmpDataPath=/vmagentdata
+    configs:
+      - source: vmagent-scrape-config
+        target: /etc/vmagent/prometheus.yml
+    volumes:
+      - /data/vmagent:/vmagentdata
+    depends_on:
+      - victoriametrics
+      - cadvisor
+    networks:
+      - monitoring
+
   loki:
     image: grafana/loki:latest
     container_name: loki
@@ -42,6 +78,10 @@ services:
       - /data/loki:/loki
     networks:
       - monitoring
+
+configs:
+  vmagent-scrape-config:
+    file: ./vmagent/prometheus.yml
 
 networks:
   monitoring:

--- a/portainer/vmagent/prometheus.yml
+++ b/portainer/vmagent/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: beelink-cadvisor
+    static_configs:
+      - targets:
+          - cadvisor:8080
+        labels:
+          host: beelink
+          service: cadvisor


### PR DESCRIPTION
## Summary
- add cAdvisor with least-privilege read-only host and Docker mounts
- add vmagent to scrape cAdvisor and remote-write into VictoriaMetrics
- version the scrape config and document deployment and verification

## Validation
- YAML parsed with PyYAML
- `git diff --check` passes
- cAdvisor and vmagent image manifests verified for amd64

The downstream Kanban validation task will exercise deployment and live metric ingestion.