### PR TITLE
feat: add GitOps restic backup stack

### DIFF
--- a/portainer/restic-backup.yaml
+++ b/portainer/restic-backup.yaml
@@ -1,0 +1,39 @@
+# Nightly restic backup for the Portainer-managed host.
+#
+# Required Portainer stack environment variables:
+#   RESTIC_REPOSITORY      s3:s3.amazonaws.com/<bucket>/hosts/<host>/portainer
+#   RESTIC_PASSWORD        restic repository password
+#   AWS_ACCESS_KEY_ID      S3 access key
+#   AWS_SECRET_ACCESS_KEY  S3 secret key
+# Optional:
+#   AWS_SESSION_TOKEN      temporary-session token
+#   AWS_DEFAULT_REGION     defaults to eu-central-1
+#
+# The backup image deliberately mounts /data read-only, but the backup scripts
+# pass only /data/portainer, /data/hermes, and /data/hindsight to restic.
+services:
+  restic-backup:
+    build:
+      context: ./portainer/restic-backup
+      dockerfile: Dockerfile
+    image: selfhosted-restic-backup:0.19.1
+    container_name: restic-backup
+    hostname: portainer-host
+    restart: unless-stopped
+    init: true
+    environment:
+      TZ: Europe/Berlin
+      RESTIC_REPOSITORY: "${RESTIC_REPOSITORY:?RESTIC_REPOSITORY must be set in Portainer}"
+      RESTIC_PASSWORD: "${RESTIC_PASSWORD:?RESTIC_PASSWORD must be set in Portainer}"
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set in Portainer}"
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set in Portainer}"
+      AWS_SESSION_TOKEN: "${AWS_SESSION_TOKEN:-}"
+      AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION:-eu-central-1}"
+      RESTIC_CACHE_DIR: /tmp/restic-cache
+    volumes:
+      - /data:/data:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    read_only: true
+    tmpfs:
+      - /run
+      - /tmp

--- a/portainer/restic-backup/.dockerignore
+++ b/portainer/restic-backup/.dockerignore
@@ -1,0 +1,8 @@
+*
+!Dockerfile
+!entrypoint.sh
+!common.sh
+!backup.sh
+!prune.sh
+!check.sh
+!crontab

--- a/portainer/restic-backup/Dockerfile
+++ b/portainer/restic-backup/Dockerfile
@@ -1,0 +1,22 @@
+FROM restic/restic:0.19.1
+
+USER root
+
+# The official restic image is Alpine-based. docker-cli is required by the
+# pre/post backup lifecycle script to stop and restart the selected containers.
+RUN apk add --no-cache docker-cli tzdata
+
+ENV TZ=Europe/Berlin \
+    RESTIC_CACHE_DIR=/tmp/restic-cache
+
+COPY --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chmod=0755 common.sh /usr/local/lib/restic-backup-common.sh
+COPY --chmod=0755 backup.sh /usr/local/bin/backup.sh
+COPY --chmod=0755 prune.sh /usr/local/bin/prune.sh
+COPY --chmod=0755 check.sh /usr/local/bin/check.sh
+COPY --chmod=0644 crontab /etc/crontabs/root
+
+RUN ln -snf /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
+    && printf '%s\n' Europe/Berlin > /etc/timezone
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/portainer/restic-backup/README.md
+++ b/portainer/restic-backup/README.md
@@ -1,0 +1,90 @@
+# Restic backup stack
+
+This stack is intended for the local Docker endpoint and is deployed through
+Portainer GitOps from `portainer/restic-backup.yaml`.
+
+## Scope
+
+The container mounts `/data` read-only, but restic is passed exactly these
+three paths:
+
+```text
+/data/portainer
+/data/hermes
+/data/hindsight
+```
+
+The Docker socket is mounted so the backup job can stop and restart exactly
+these containers before and after the backup:
+
+```text
+hindsight
+hermes
+portainer
+```
+
+The monitoring stack is not stopped and none of its data paths are passed to
+restic.
+
+## Portainer environment variables
+
+Set these in the Portainer stack environment before deploying:
+
+```text
+RESTIC_REPOSITORY=s3:s3.amazonaws.com/<bucket>/hosts/<host>/portainer
+RESTIC_PASSWORD=<long random restic repository password>
+AWS_ACCESS_KEY_ID=<S3 access key>
+AWS_SECRET_ACCESS_KEY=<S3 secret key>
+AWS_DEFAULT_REGION=eu-central-1
+```
+
+If the AWS credential is temporary, also set `AWS_SESSION_TOKEN`.
+
+Do not commit any of these values to Git. The restic repository password must
+be stored separately from the S3 credentials and retained offline; losing it
+makes the encrypted repository unrecoverable.
+
+## Initial setup
+
+The scheduled job intentionally does not initialize a repository. After the
+S3 variables are configured, initialize it once from the running container:
+
+```bash
+docker exec restic-backup restic init
+```
+
+Run one manual backup and inspect the logs before relying on the scheduler:
+
+```bash
+docker exec restic-backup /usr/local/bin/backup.sh
+docker logs --since 10m restic-backup
+```
+
+The backup is scheduled for `03:00` in `Europe/Berlin`. Repository pruning runs
+at `03:30` on Sundays, and a 5% data check runs at `04:00` on Sundays.
+
+Retention is:
+
+```text
+14 daily, 8 weekly, 12 monthly, 3 yearly snapshots
+```
+
+## Restore test
+
+List snapshots:
+
+```bash
+docker exec restic-backup restic snapshots
+```
+
+Restore to a temporary host directory rather than directly over live state:
+
+```bash
+mkdir -p /var/tmp/restic-restore-test
+docker exec restic-backup \
+  restic restore latest --target /var/tmp/restic-restore-test
+```
+
+The restic container mounts `/data` read-only and does not back up the Docker
+socket, credentials, images, host OS, Docker engine configuration, or
+monitoring data.

--- a/portainer/restic-backup/backup.sh
+++ b/portainer/restic-backup/backup.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -eu
+
+. /usr/local/lib/restic-backup-common.sh
+acquire_lock
+
+# These are the only containers intentionally stopped. Monitoring is not
+# touched. The names match the current Portainer deployment.
+STOP_ORDER='hindsight hermes portainer'
+START_ORDER='portainer hindsight hermes'
+RUNNING_FILE=/run/restic-backup.running
+: > "$RUNNING_FILE"
+
+finish() {
+  rc=$?
+
+  # Restore the pre-backup running state even when restic or a stop operation
+  # fails. Containers that were already stopped are not started.
+  for container in $START_ORDER; do
+    if grep -Fqx "$container" "$RUNNING_FILE"; then
+      if ! docker start "$container" >/dev/null; then
+        printf 'failed to restart %s\n' "$container" >&2
+        rc=1
+      fi
+    fi
+  done
+
+  rm -f "$RUNNING_FILE"
+  release_lock
+
+  if [ "$rc" -ne 0 ]; then
+    printf 'restic backup failed\n' >&2
+  fi
+  exit "$rc"
+}
+trap finish EXIT INT TERM
+
+# Fail closed if the expected containers were renamed or removed. Backing up a
+# live database would otherwise create a misleadingly successful snapshot.
+for container in $STOP_ORDER; do
+  if ! docker inspect "$container" >/dev/null 2>&1; then
+    printf 'required container is missing: %s\n' "$container" >&2
+    exit 1
+  fi
+done
+
+for container in $STOP_ORDER; do
+  if [ "$(docker inspect -f '{{.State.Running}}' "$container")" = true ]; then
+    printf '%s\n' "$container" >> "$RUNNING_FILE"
+  fi
+done
+
+while IFS= read -r container; do
+  [ -n "$container" ] || continue
+  printf 'stopping %s\n' "$container"
+  docker stop --time=60 "$container" >/dev/null
+done < "$RUNNING_FILE"
+
+# Keep this list explicit. Do not replace it with /data or a wildcard: the
+# monitoring data under /data is intentionally outside the backup scope.
+restic backup \
+  --tag portainer-host \
+  --tag nightly \
+  /data/portainer \
+  /data/hermes \
+  /data/hindsight

--- a/portainer/restic-backup/check.sh
+++ b/portainer/restic-backup/check.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+. /usr/local/lib/restic-backup-common.sh
+acquire_lock
+trap release_lock EXIT INT TERM
+
+restic check \
+  --tag portainer-host \
+  --read-data-subset=5%

--- a/portainer/restic-backup/common.sh
+++ b/portainer/restic-backup/common.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+umask 077
+
+: "${RESTIC_REPOSITORY:?RESTIC_REPOSITORY must be set}"
+: "${RESTIC_PASSWORD:?RESTIC_PASSWORD must be set}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
+: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION must be set}"
+
+export RESTIC_REPOSITORY RESTIC_PASSWORD AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION
+export AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
+export RESTIC_CACHE_DIR="${RESTIC_CACHE_DIR:-/tmp/restic-cache}"
+
+mkdir -p "$RESTIC_CACHE_DIR"
+
+LOCK_DIR=/run/restic-backup.lock
+
+acquire_lock() {
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    printf '%s\n' 'another restic operation is already running; skipping' >&2
+    exit 0
+  fi
+}
+
+release_lock() {
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}

--- a/portainer/restic-backup/crontab
+++ b/portainer/restic-backup/crontab
@@ -1,0 +1,7 @@
+# Europe/Berlin is configured in the image and compose environment.
+# Backup every night at 03:00 local time.
+0 3 * * * /usr/local/bin/backup.sh >>/proc/1/fd/1 2>>/proc/1/fd/2
+# Compact the repository weekly, after the Sunday backup has completed.
+30 3 * * 0 /usr/local/bin/prune.sh >>/proc/1/fd/1 2>>/proc/1/fd/2
+# Sample repository data weekly after pruning.
+0 4 * * 0 /usr/local/bin/check.sh >>/proc/1/fd/1 2>>/proc/1/fd/2

--- a/portainer/restic-backup/entrypoint.sh
+++ b/portainer/restic-backup/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+# The image contains tzdata and the compose file sets TZ explicitly. Keep the
+# link here as well so cron uses Europe/Berlin rather than UTC.
+if [ -n "${TZ:-}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
+  ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime
+  printf '%s\n' "$TZ" > /etc/timezone
+fi
+
+mkdir -p "${RESTIC_CACHE_DIR:-/tmp/restic-cache}"
+
+# Keep the scheduler in the foreground so Docker restarts the service if cron
+# exits and all job output remains visible through `docker logs`.
+exec crond -f -l 2 -L /dev/stdout

--- a/portainer/restic-backup/prune.sh
+++ b/portainer/restic-backup/prune.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+. /usr/local/lib/restic-backup-common.sh
+acquire_lock
+trap release_lock EXIT INT TERM
+
+restic forget \
+  --tag portainer-host \
+  --keep-daily 14 \
+  --keep-weekly 8 \
+  --keep-monthly 12 \
+  --keep-yearly 3 \
+  --prune


### PR DESCRIPTION
## Summary
- Adds a GitOps-managed restic backup container.
- Backs up only `/data/portainer`, `/data/hermes`, and `/data/hindsight`.
- Stops and restarts only `hindsight`, `hermes`, and `portainer` around the backup.
- Schedules the backup at 03:00 Europe/Berlin, with weekly prune and integrity checks.

## Secrets
No credentials are committed. The Portainer stack requires the documented Restic and AWS environment variables.

## Verification
- Shell syntax checks passed.
- Compose YAML structure and mount scope validated.
- Restic base image tag `0.19.1` verified to exist.
