### PR TITLE
fix: correct restic GitOps build context

### DIFF
--- a/portainer/restic-backup.yaml
+++ b/portainer/restic-backup.yaml
@@ -14,7 +14,7 @@
 services:
   restic-backup:
     build:
-      context: ./portainer/restic-backup
+      context: ./restic-backup
       dockerfile: Dockerfile
     image: selfhosted-restic-backup:0.19.1
     container_name: restic-backup


### PR DESCRIPTION
Fixes the Git-backed Portainer build context so the restic image resolves `./restic-backup` relative to the `portainer/` Compose project directory.