### PR TITLE
fix: avoid timezone relink on read-only restic container

### DIFF
--- a/portainer/restic-backup/entrypoint.sh
+++ b/portainer/restic-backup/entrypoint.sh
@@ -1,13 +1,6 @@
 #!/bin/sh
 set -eu
 
-# The image contains tzdata and the compose file sets TZ explicitly. Keep the
-# link here as well so cron uses Europe/Berlin rather than UTC.
-if [ -n "${TZ:-}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
-  ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime
-  printf '%s\n' "$TZ" > /etc/timezone
-fi
-
 mkdir -p "${RESTIC_CACHE_DIR:-/tmp/restic-cache}"
 
 # Keep the scheduler in the foreground so Docker restarts the service if cron


### PR DESCRIPTION
Removes the redundant `/etc/localtime` relink from the read-only restic container entrypoint. The Dockerfile already sets the Europe/Berlin timezone during image build.