### PR TITLE
fix: guard restic backup placeholders

### DIFF
--- a/portainer/restic-backup/common.sh
+++ b/portainer/restic-backup/common.sh
@@ -9,6 +9,14 @@ umask 077
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 : "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION must be set}"
 
+# Portainer is initially deployed with placeholders so the stack can be
+# edited safely. Fail before any container is stopped until real credentials
+# and a real repository are configured.
+case "$RESTIC_REPOSITORY" in *REPLACE_WITH*) printf '%s\n' 'RESTIC_REPOSITORY is still a placeholder' >&2; exit 1;; esac
+case "$RESTIC_PASSWORD" in *REPLACE_WITH*) printf '%s\n' 'RESTIC_PASSWORD is still a placeholder' >&2; exit 1;; esac
+case "$AWS_ACCESS_KEY_ID" in *REPLACE_WITH*) printf '%s\n' 'AWS_ACCESS_KEY_ID is still a placeholder' >&2; exit 1;; esac
+case "$AWS_SECRET_ACCESS_KEY" in *REPLACE_WITH*) printf '%s\n' 'AWS_SECRET_ACCESS_KEY is still a placeholder' >&2; exit 1;; esac
+
 export RESTIC_REPOSITORY RESTIC_PASSWORD AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION
 export AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN:-}"
 export RESTIC_CACHE_DIR="${RESTIC_CACHE_DIR:-/tmp/restic-cache}"


### PR DESCRIPTION
Ensure the initially deployed Portainer placeholder values fail before any application containers are stopped. This keeps the nightly scheduler harmless until real S3 and Restic credentials are configured.