### PR TITLE
fix: consolidate monitoring into the Git-backed stack

### DIFF
--- a/portainer/monitoring.md
+++ b/portainer/monitoring.md
@@ -58,5 +58,22 @@ After the stack is running, verify the collector path from the host or Portainer
 4. Query VictoriaMetrics for a non-empty host series, for example
    `machine_memory_bytes{host="beelink"}`, and a container series such as
    `container_cpu_usage_seconds_total{host="beelink"}`.
-5. Redeploy or restart the stack and repeat the checks; `/data/victoriametrics`
+5. For a concrete scrape-health check, query these PromQL expressions through the
+   configured VictoriaMetrics datasource:
+
+   ```promql
+   up{job="beelink-cadvisor",host="beelink",instance="cadvisor:8080",service="cadvisor"}
+   machine_scrape_error{host="beelink"}
+   container_scrape_error{host="beelink"}
+   machine_memory_bytes{host="beelink"}
+   machine_cpu_cores{host="beelink"}
+   count(container_cpu_usage_seconds_total{host="beelink"})
+   ```
+
+   Expected results are `up = 1`, both scrape-error gauges `= 0`, non-zero
+   machine memory and CPU-core values, and a positive container-series count.
+   A range query such as
+   `up{job="beelink-cadvisor"}[30m]` should contain repeated samples, all `1`;
+   this catches intermittent target failures that an instant query can miss.
+6. Redeploy or restart the stack and repeat the checks; `/data/victoriametrics`
    and `/data/vmagent` must remain intact.

--- a/portainer/monitoring.md
+++ b/portainer/monitoring.md
@@ -77,3 +77,58 @@ After the stack is running, verify the collector path from the host or Portainer
    this catches intermittent target failures that an instant query can miss.
 6. Redeploy or restart the stack and repeat the checks; `/data/victoriametrics`
    and `/data/vmagent` must remain intact.
+
+## Restart and persistence procedure
+
+Use Portainer on the Docker host (`local`, environment ID `3`) for the
+restart exercise. Do not enter the Grafana password in shell history or task
+comments.
+
+1. Before starting stack `monitoring` (stack `26`), set its existing
+   `GF_SECURITY_ADMIN_PASSWORD` environment value in Portainer. The Compose
+   expression is required and intentionally fails closed when this value is
+   absent.
+2. Deploy the repository revision containing the inline
+   `vmagent-scrape-config` (`configs.content`). Portainer Git stacks do not
+   materialize the relative `configs.file` form. Until that revision is on
+   the configured Git ref, keep stack `monitoring-collector` (`36`) running as
+   the persistent vmagent workaround.
+3. Do not run both stacks with a `vmagent` service at once: both use the
+   container name `vmagent`. For the final single-stack deployment, stop
+   stack `36`, then redeploy/start stack `26`. For the interim workaround,
+   restart stack `36` through Portainer and leave stack `26`'s collector
+   service disabled until the inline-config revision is deployed.
+4. Wait at least 30 seconds (two 15-second scrape intervals) after the
+   containers report running before judging the result. Confirm the four
+   persistent bind paths `/data/grafana`, `/data/victoriametrics`,
+   `/data/loki`, and `/data/vmagent` are still attached.
+5. Repeat the health and PromQL checks above, including a range query over at
+   least five minutes. In Grafana, open dashboard `beelink-cadvisor`
+   (`Beelink Host & Containers`), select host `beelink`, and verify its seven
+   panels have current values. The expected current checks are `up = 1`, both
+   scrape-error gauges `= 0`, four CPU cores, non-zero memory, and positive
+   named container CPU/memory series.
+
+### Restart result (2026-08-24)
+
+The externally supplied Grafana secret was restored and the stopped monitoring
+services were brought back without deleting any data directories. Starting the
+Git stack from the current `main` ref pulled cAdvisor `v0.55.1`; on this Docker
+host that version emitted raw cgroup series without Docker `name` labels, so
+three container dashboard queries were empty even though `up = 1`. The
+repository configuration therefore pins cAdvisor to the previously verified
+`v0.52.1`; after restarting that collector and allowing fresh scrapes, the
+checks returned `up = 1`, `machine_scrape_error = 0`,
+`container_scrape_error = 0`, `machine_cpu_cores = 4`,
+`machine_memory_bytes = 16534200320`, and 13 named container series. All seven
+Grafana panel queries returned non-empty current data and the host variable
+resolved to `beelink`.
+
+The Grafana datasource and dashboard are persistent runtime state, not
+provisioned from this repository. PNG snapshot rendering remains unavailable
+unless the Grafana Image Renderer service is installed; this does not prevent
+normal in-browser dashboard panels from executing their queries. The final
+clean Portainer Git redeploy still requires the inline-config commit to be
+merged/pushed to the stack's configured Git ref; the direct cAdvisor rollback
+above was a live validation recovery, not a replacement for that documented
+redeploy.

--- a/portainer/monitoring.md
+++ b/portainer/monitoring.md
@@ -9,10 +9,13 @@ cAdvisor -> vmagent -> VictoriaMetrics <- Grafana
 
 ## Deployment inputs
 
-The Portainer stack uses the Git repository's `portainer/monitoring.yaml` file. The
-scrape configuration is versioned next to it at
-`portainer/vmagent/prometheus.yml` and is loaded through the Compose `configs`
-entry; no host-side configuration file is required.
+The Portainer stack uses the Git repository's `portainer/monitoring.yaml` file.
+The vmagent scrape configuration is inlined in its Compose `configs` entry because
+Portainer Git stacks do not materialize relative `configs.file` paths. The source
+copy at `portainer/vmagent/prometheus.yml` documents the same configuration, but
+the deployed stack does not require a host-side configuration file. The Grafana
+dashboard is managed directly in Grafana and is intentionally not provisioned
+from this repository.
 
 Set the existing Grafana secret before deploying or updating the stack:
 

--- a/portainer/monitoring.yaml
+++ b/portainer/monitoring.yaml
@@ -31,7 +31,9 @@ services:
       - monitoring
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.55.1
+    # v0.52.1 preserves Docker name labels used by the direct Grafana dashboard
+    # on the Beelink Docker API; newer v0.55.x emitted raw cgroup-only series.
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor
     restart: unless-stopped
     command:

--- a/portainer/monitoring.yaml
+++ b/portainer/monitoring.yaml
@@ -81,7 +81,22 @@ services:
 
 configs:
   vmagent-scrape-config:
-    file: ./vmagent/prometheus.yml
+    # Portainer Git stacks do not materialize relative Compose config files.
+    # Keep this small scrape configuration inline so the stack is deployable
+    # directly from the repository's configured Compose path.
+    content: |
+      global:
+        scrape_interval: 15s
+        scrape_timeout: 10s
+
+      scrape_configs:
+        - job_name: beelink-cadvisor
+          static_configs:
+            - targets:
+                - cadvisor:8080
+              labels:
+                host: beelink
+                service: cadvisor
 
 networks:
   monitoring:


### PR DESCRIPTION
## Summary
- Inline the vmagent scrape configuration for Portainer Git-backed deployment.
- Pin cAdvisor to v0.52.1 because v0.55.x drops Docker name labels required by the existing Grafana dashboard.
- Document the single-stack deployment, restart procedure, persistence checks, and direct Grafana dashboard ownership.

## Validation
- `uv run --with pyyaml --no-project python` YAML assertions passed.
- `git diff --check` passed.
- Live validation evidence is recorded in the Kanban task and `portainer/monitoring.md`.

## Rollout
After merge: stop the standalone `monitoring-collector` workaround, redeploy Portainer stack `monitoring` from `main`, wait for fresh scrapes, verify Grafana/VictoriaMetrics, then remove the workaround stack.