### PR TITLE
feat: add Papra document archive stack

### DIFF
--- a/portainer/papra.yaml
+++ b/portainer/papra.yaml
@@ -1,0 +1,35 @@
+# Papra document archiving platform.
+#
+# Required Portainer stack environment variable:
+#   AUTH_SECRET  random secret of at least 32 characters
+#
+# The application data is kept on the host at /data/papra so it is included in
+# the host's restic backup set.
+services:
+  papra-init:
+    image: alpine:3.22
+    container_name: papra-init
+    user: "0:0"
+    restart: "no"
+    command:
+      - /bin/sh
+      - -c
+      - mkdir -p /app/app-data && chown -R 1000:1000 /app/app-data
+    volumes:
+      - /data/papra:/app/app-data
+
+  papra:
+    image: ghcr.io/papra-hq/papra:latest
+    container_name: papra
+    restart: unless-stopped
+    user: "1000:1000"
+    depends_on:
+      papra-init:
+        condition: service_completed_successfully
+    ports:
+      - "1221:1221"
+    environment:
+      AUTH_SECRET: "${AUTH_SECRET:?AUTH_SECRET must be set in Portainer}"
+      APP_BASE_URL: "${APP_BASE_URL:-http://localhost:1221}"
+    volumes:
+      - /data/papra:/app/app-data

--- a/portainer/restic-backup.yaml
+++ b/portainer/restic-backup.yaml
@@ -10,7 +10,7 @@
 #   AWS_DEFAULT_REGION     defaults to eu-central-1
 #
 # The backup image deliberately mounts /data read-only, but the backup scripts
-# pass only /data/portainer, /data/hermes, and /data/hindsight to restic.
+# pass only the explicit application paths to restic, including /data/papra.
 services:
   restic-backup:
     build:

--- a/portainer/restic-backup/README.md
+++ b/portainer/restic-backup/README.md
@@ -6,18 +6,20 @@ Portainer GitOps from `portainer/restic-backup.yaml`.
 ## Scope
 
 The container mounts `/data` read-only, but restic is passed exactly these
-three paths:
+four paths:
 
 ```text
 /data/portainer
 /data/hermes
 /data/hindsight
+/data/papra
 ```
 
 The Docker socket is mounted so the backup job can stop and restart exactly
 these containers before and after the backup:
 
 ```text
+papra
 hindsight
 hermes
 portainer
@@ -87,4 +89,5 @@ docker exec restic-backup \
 
 The restic container mounts `/data` read-only and does not back up the Docker
 socket, credentials, images, host OS, Docker engine configuration, or
-monitoring data.
+monitoring data. Papra's `AUTH_SECRET` is a Portainer environment variable and
+is intentionally not stored in Git or in the restic Compose file.

--- a/portainer/restic-backup/backup.sh
+++ b/portainer/restic-backup/backup.sh
@@ -6,8 +6,8 @@ acquire_lock
 
 # These are the only containers intentionally stopped. Monitoring is not
 # touched. The names match the current Portainer deployment.
-STOP_ORDER='hindsight hermes portainer'
-START_ORDER='portainer hindsight hermes'
+STOP_ORDER='papra hindsight hermes portainer'
+START_ORDER='portainer hermes hindsight papra'
 RUNNING_FILE=/run/restic-backup.running
 : > "$RUNNING_FILE"
 
@@ -63,4 +63,5 @@ restic backup \
   --tag nightly \
   /data/portainer \
   /data/hermes \
-  /data/hindsight
+  /data/hindsight \
+  /data/papra


### PR DESCRIPTION
## Summary
- add Papra Git-backed Portainer stack at `portainer/papra.yaml`
- use a Portainer-only `AUTH_SECRET` and `/data/papra` bind mount
- include Papra in the explicit restic stop and backup scope

## Verification
- YAML parse passed
- shell syntax checks passed
- `git diff --check` passed
- no `AUTH_SECRET` literal committed

Deployment will be performed after merge.