### PR TITLE
fix: set Papra application origin

### DIFF
--- a/portainer/papra.yaml
+++ b/portainer/papra.yaml
@@ -15,6 +15,6 @@ services:
       - "1221:1221"
     environment:
       AUTH_SECRET: "${AUTH_SECRET:?AUTH_SECRET must be set in Portainer}"
-      APP_BASE_URL: "${APP_BASE_URL:-http://localhost:1221}"
+      APP_BASE_URL: "${APP_BASE_URL:-http://192.168.178.13:1221}"
     volumes:
       - /data/papra:/app/app-data


### PR DESCRIPTION
Set Papra `APP_BASE_URL` default to `http://192.168.178.13:1221` so CSRF origin validation matches the LAN URL.

GitOps source change only; no live Portainer redeploy.