### PR TITLE
fix: exclude Hermes from restic backup

### DIFF
--- a/portainer/restic-backup.yaml
+++ b/portainer/restic-backup.yaml
@@ -10,7 +10,7 @@
 #   AWS_DEFAULT_REGION     defaults to eu-central-1
 #
 # The backup image deliberately mounts /data read-only, but the backup scripts
-# pass only the explicit application paths to restic, including /data/papra.
+# pass only the explicit application paths to restic.
 services:
   restic-backup:
     build:

--- a/portainer/restic-backup/README.md
+++ b/portainer/restic-backup/README.md
@@ -6,11 +6,10 @@ Portainer GitOps from `portainer/restic-backup.yaml`.
 ## Scope
 
 The container mounts `/data` read-only, but restic is passed exactly these
-four paths:
+three paths:
 
 ```text
 /data/portainer
-/data/hermes
 /data/hindsight
 /data/papra
 ```
@@ -21,7 +20,6 @@ these containers before and after the backup:
 ```text
 papra
 hindsight
-hermes
 portainer
 ```
 

--- a/portainer/restic-backup/backup.sh
+++ b/portainer/restic-backup/backup.sh
@@ -6,8 +6,8 @@ acquire_lock
 
 # These are the only containers intentionally stopped. Monitoring is not
 # touched. The names match the current Portainer deployment.
-STOP_ORDER='papra hindsight hermes portainer'
-START_ORDER='portainer hermes hindsight papra'
+STOP_ORDER='papra hindsight portainer'
+START_ORDER='portainer hindsight papra'
 RUNNING_FILE=/run/restic-backup.running
 : > "$RUNNING_FILE"
 
@@ -62,6 +62,5 @@ restic backup \
   --tag portainer-host \
   --tag nightly \
   /data/portainer \
-  /data/hermes \
   /data/hindsight \
   /data/papra


### PR DESCRIPTION
Remove Hermes state from the restic backup scope and stop/restart lists. Keep the backup limited to Portainer, Hindsight, and Papra data.