### PR TITLE
fix: reduce restic retention window

### DIFF
--- a/portainer/restic-backup/README.md
+++ b/portainer/restic-backup/README.md
@@ -66,7 +66,7 @@ at `03:30` on Sundays, and a 5% data check runs at `04:00` on Sundays.
 Retention is:
 
 ```text
-14 daily, 8 weekly, 12 monthly, 3 yearly snapshots
+7 daily, 4 weekly, 6 monthly, 3 yearly snapshots
 ```
 
 ## Restore test

--- a/portainer/restic-backup/prune.sh
+++ b/portainer/restic-backup/prune.sh
@@ -7,8 +7,8 @@ trap release_lock EXIT INT TERM
 
 restic forget \
   --tag portainer-host \
-  --keep-daily 14 \
-  --keep-weekly 8 \
-  --keep-monthly 12 \
+  --keep-daily 7 \
+  --keep-weekly 4 \
+  --keep-monthly 6 \
   --keep-yearly 3 \
   --prune


### PR DESCRIPTION
Set Restic retention to 7 daily, 4 weekly, 6 monthly, and 3 yearly snapshots. GitOps will apply the change; no redeploy is performed here.