### PR TITLE
feat: add Hermes WebUI to stack

### DIFF
--- a/portainer/hermes.yaml
+++ b/portainer/hermes.yaml
@@ -1,4 +1,4 @@
-# Hermes gateway, WebUI, plus colocated Hindsight service.
+# Hermes gateway, independent WebUI, plus colocated Hindsight service.
 #
 # Important: do not deploy this stack while the current standalone `hermes`
 # container is still running, or host ports/container names will conflict.
@@ -15,20 +15,19 @@ services:
       HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "${HERMES_DASHBOARD_BASIC_AUTH_USERNAME:?HERMES_DASHBOARD_BASIC_AUTH_USERNAME must be set}"
       HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "${HERMES_DASHBOARD_BASIC_AUTH_PASSWORD:?HERMES_DASHBOARD_BASIC_AUTH_PASSWORD must be set}"
       HERMES_DASHBOARD_BASIC_AUTH_SECRET: "${HERMES_DASHBOARD_BASIC_AUTH_SECRET:?HERMES_DASHBOARD_BASIC_AUTH_SECRET must be set}"
-      API_SERVER_ENABLED: "true"
-      API_SERVER_HOST: "0.0.0.0"
-      API_SERVER_KEY: "${API_SERVER_KEY:?API_SERVER_KEY must be set}"
     ports:
       - "8642:8642"
       - "9119:9119"
     volumes:
       - /data/hermes:/opt/data
-      # Both services must see the same path for gateway-backed browser sessions.
+      # Both frontends see the same project files through this path.
       - ${HERMES_WORKSPACE:-/data/hermes/workspace}:/workspace
       # The source volume is initialized from /opt/hermes in this image.
       # Recreate it after an agent image upgrade to refresh the source copy.
       - hermes-agent-src:/opt/hermes
 
+  # The WebUI intentionally runs its own in-process agent. It shares the Hermes
+  # home, agent source, and workspace with the gateway service.
   hermes-webui:
     # Source: https://github.com/nesquena/hermes-webui
     # Pinned experimental release aligned with Hermes Agent v2026.8.27.
@@ -53,11 +52,6 @@ services:
       HERMES_WEBUI_STATE_DIR: "/home/hermeswebui/.hermes/webui"
       HERMES_WEBUI_DEFAULT_WORKSPACE: "/workspace"
       HERMES_WEBUI_PASSWORD: "${HERMES_WEBUI_PASSWORD:-}"
-      HERMES_WEBUI_CHAT_BACKEND: "gateway"
-      HERMES_WEBUI_GATEWAY_BASE_URL: "http://hermes:8642"
-      HERMES_WEBUI_GATEWAY_API_KEY: "${API_SERVER_KEY:?API_SERVER_KEY must be set}"
-      HERMES_WEBUI_GATEWAY_USE_RUNS_API: "true"
-      HERMES_API_URL: "http://hermes:8642"
 
   hindsight:
     image: ghcr.io/vectorize-io/hindsight:0.9.2

--- a/portainer/hermes.yaml
+++ b/portainer/hermes.yaml
@@ -4,7 +4,7 @@
 # container is still running, or host ports/container names will conflict.
 services:
   hermes:
-    image: nousresearch/hermes-agent:v2026.8.19
+    image: nousresearch/hermes-agent:v2026.8.27
     container_name: hermes
     restart: always
     command:
@@ -15,18 +15,24 @@ services:
       HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "${HERMES_DASHBOARD_BASIC_AUTH_USERNAME:?HERMES_DASHBOARD_BASIC_AUTH_USERNAME must be set}"
       HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "${HERMES_DASHBOARD_BASIC_AUTH_PASSWORD:?HERMES_DASHBOARD_BASIC_AUTH_PASSWORD must be set}"
       HERMES_DASHBOARD_BASIC_AUTH_SECRET: "${HERMES_DASHBOARD_BASIC_AUTH_SECRET:?HERMES_DASHBOARD_BASIC_AUTH_SECRET must be set}"
+      API_SERVER_ENABLED: "true"
+      API_SERVER_HOST: "0.0.0.0"
+      API_SERVER_KEY: "${API_SERVER_KEY:?API_SERVER_KEY must be set}"
     ports:
       - "8642:8642"
       - "9119:9119"
     volumes:
       - /data/hermes:/opt/data
+      # Both services must see the same path for gateway-backed browser sessions.
+      - ${HERMES_WORKSPACE:-/data/hermes/workspace}:/workspace
       # The source volume is initialized from /opt/hermes in this image.
       # Recreate it after an agent image upgrade to refresh the source copy.
       - hermes-agent-src:/opt/hermes
 
   hermes-webui:
     # Source: https://github.com/nesquena/hermes-webui
-    image: ghcr.io/nesquena/hermes-webui:0.52.113
+    # Pinned experimental release aligned with Hermes Agent v2026.8.27.
+    image: ghcr.io/nesquena/hermes-webui:0.52.264
     container_name: hermes-webui
     depends_on:
       - hermes
@@ -39,7 +45,7 @@ services:
       # The WebUI reads the agent source to install its Python dependencies.
       - hermes-agent-src:/home/hermeswebui/.hermes/hermes-agent:ro
       # Persist the UI workspace separately from Hermes configuration/state.
-      - ${HERMES_WEBUI_WORKSPACE:-/data/hermes/workspace}:/workspace
+      - ${HERMES_WORKSPACE:-/data/hermes/workspace}:/workspace
     environment:
       HERMES_HOME: "/home/hermeswebui/.hermes"
       HERMES_WEBUI_HOST: "0.0.0.0"
@@ -47,6 +53,10 @@ services:
       HERMES_WEBUI_STATE_DIR: "/home/hermeswebui/.hermes/webui"
       HERMES_WEBUI_DEFAULT_WORKSPACE: "/workspace"
       HERMES_WEBUI_PASSWORD: "${HERMES_WEBUI_PASSWORD:-}"
+      HERMES_WEBUI_CHAT_BACKEND: "gateway"
+      HERMES_WEBUI_GATEWAY_BASE_URL: "http://hermes:8642"
+      HERMES_WEBUI_GATEWAY_API_KEY: "${API_SERVER_KEY:?API_SERVER_KEY must be set}"
+      HERMES_WEBUI_GATEWAY_USE_RUNS_API: "true"
       HERMES_API_URL: "http://hermes:8642"
 
   hindsight:

--- a/portainer/hermes.yaml
+++ b/portainer/hermes.yaml
@@ -1,4 +1,4 @@
-# Hermes gateway plus colocated Hindsight service.
+# Hermes gateway, WebUI, plus colocated Hindsight service.
 #
 # Important: do not deploy this stack while the current standalone `hermes`
 # container is still running, or host ports/container names will conflict.
@@ -20,6 +20,34 @@ services:
       - "9119:9119"
     volumes:
       - /data/hermes:/opt/data
+      # The source volume is initialized from /opt/hermes in this image.
+      # Recreate it after an agent image upgrade to refresh the source copy.
+      - hermes-agent-src:/opt/hermes
+
+  hermes-webui:
+    # Source: https://github.com/nesquena/hermes-webui
+    image: ghcr.io/nesquena/hermes-webui:0.52.113
+    container_name: hermes-webui
+    depends_on:
+      - hermes
+    restart: unless-stopped
+    ports:
+      # Keep the UI on loopback; expose it through the existing host tunnel.
+      - "127.0.0.1:8787:8787"
+    volumes:
+      - /data/hermes:/home/hermeswebui/.hermes
+      # The WebUI reads the agent source to install its Python dependencies.
+      - hermes-agent-src:/home/hermeswebui/.hermes/hermes-agent:ro
+      # Persist the UI workspace separately from Hermes configuration/state.
+      - ${HERMES_WEBUI_WORKSPACE:-/data/hermes/workspace}:/workspace
+    environment:
+      HERMES_HOME: "/home/hermeswebui/.hermes"
+      HERMES_WEBUI_HOST: "0.0.0.0"
+      HERMES_WEBUI_PORT: "8787"
+      HERMES_WEBUI_STATE_DIR: "/home/hermeswebui/.hermes/webui"
+      HERMES_WEBUI_DEFAULT_WORKSPACE: "/workspace"
+      HERMES_WEBUI_PASSWORD: "${HERMES_WEBUI_PASSWORD:-}"
+      HERMES_API_URL: "http://hermes:8642"
 
   hindsight:
     image: ghcr.io/vectorize-io/hindsight:0.9.2
@@ -49,3 +77,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 60s
+
+volumes:
+  hermes-agent-src:


### PR DESCRIPTION
## Summary

- Add `hermes-webui` as an independent service running the WebUI default in-process agent mode.
- Share the existing Hermes home, agent source volume, and `/workspace` path with the gateway service so both frontends operate on the same underlying configuration and project files.
- Keep the WebUI loopback-only on port `8787` and preserve the existing Hermes gateway/dashboard services.
- Align the pinned images to Hermes Agent `v2026.8.27` and WebUI `0.52.264`.

## Runtime model

The WebUI is intentionally a second Hermes runtime. It can use the same profiles, configuration, skills, and configured Hindsight backend through the shared Hermes home, but its live sessions and process state remain separate from the existing gateway. Use one chat frontend at a time to avoid concurrent writes to shared Hermes state.

WebUI tools execute inside the WebUI container. The shared `/workspace` bind mount makes project files visible to both containers, while container-installed tools and process state remain separate.

No Gateway API key is required by this change because the WebUI is not configured for Gateway-backed chat. `HERMES_WEBUI_PASSWORD` remains optional because the UI is bound to loopback; configure it if the bind is changed to a non-loopback interface.

## Validation

- YAML parsing and targeted default-mode stack assertions pass.
- `git diff --check` passes.
- Both pinned image manifests resolve successfully.
- Remote branch contains commit `ff121affb40d2f7294647463246bd1ffcc01d920`.
- Live Portainer state was inspected only; no deployment or restart was performed.
- Full `docker compose config` validation was unavailable locally because Docker 26.1.5 is installed without the Compose plugin.

The WebUI image is pinned to the selected experimental release `0.52.264`; treat it accordingly before production rollout.
