### PR TITLE
feat: stage Hermes native backups for restic

### DIFF
--- a/portainer/hermes.yaml
+++ b/portainer/hermes.yaml
@@ -20,6 +20,9 @@ services:
       - "9119:9119"
     volumes:
       - /data/hermes:/opt/data
+      # Keep native Hermes backup archives outside the main Hermes state tree.
+      # The restic stack includes this host path explicitly.
+      - /data/hermes-backup:/opt/data/backups
 
   hindsight:
     image: ghcr.io/vectorize-io/hindsight:0.9.2

--- a/portainer/restic-backup.yaml
+++ b/portainer/restic-backup.yaml
@@ -10,7 +10,8 @@
 #   AWS_DEFAULT_REGION     defaults to eu-central-1
 #
 # The backup image deliberately mounts /data read-only, but the backup scripts
-# pass only the explicit application paths to restic.
+# pass only the explicit application paths to restic, including the staged
+# Hermes backup archive path.
 services:
   restic-backup:
     build:

--- a/portainer/restic-backup/README.md
+++ b/portainer/restic-backup/README.md
@@ -6,13 +6,30 @@ Portainer GitOps from `portainer/restic-backup.yaml`.
 ## Scope
 
 The container mounts `/data` read-only, but restic is passed exactly these
-three paths:
+four paths:
 
 ```text
 /data/portainer
+/data/hermes-backup
 /data/hindsight
 /data/papra
 ```
+
+The Hermes stack mounts the host path `/data/hermes-backup` at
+`/opt/data/backups`. The Hermes cron backup job writes its ZIP archives there,
+and the restic job captures that directory as a separate backup source.
+
+Before redeploying the Hermes stack, create the host directory with ownership
+matching the Hermes container's runtime user. The current image runs as
+UID/GID `10000:10000`:
+
+```bash
+sudo install -d -o 10000 -g 10000 -m 0700 /data/hermes-backup
+```
+
+If `/data/hermes/backups` already contains archives that should be retained,
+copy them to `/data/hermes-backup` before redeploying. The new bind mount hides
+the old directory from the Hermes container.
 
 The Docker socket is mounted so the backup job can stop and restart exactly
 these containers before and after the backup:

--- a/portainer/restic-backup/backup.sh
+++ b/portainer/restic-backup/backup.sh
@@ -62,5 +62,6 @@ restic backup \
   --tag portainer-host \
   --tag nightly \
   /data/portainer \
+  /data/hermes-backup \
   /data/hindsight \
   /data/papra


### PR DESCRIPTION
## Summary
- Mount the host path `/data/hermes-backup` at `/opt/data/backups` in the Hermes stack.
- Include `/data/hermes-backup` explicitly in the restic source list.
- Keep Hermes' full state excluded from direct restic backup; the native Hermes ZIP is the staged artifact.
- Document host-directory ownership and migration of existing archives before redeployment.

The live Hermes profile cron jobs are configured separately:
- `hermes-daily-backup`: `0 0 * * *`
- `hermes-daily-backup-cleanup`: `0 6 * * *`

## Validation
- YAML parsed successfully with PyYAML.
- Mount/source assertions passed.
- Shell syntax check passed for the restic script.
- `git diff --check` passed.
- Full `docker compose config` was unavailable because this environment lacks the Compose plugin.
