### PR TITLE
feat(portainer): add Hermes Workspace sidecar

### DIFF
--- a/portainer/hermes.yaml
+++ b/portainer/hermes.yaml
@@ -24,6 +24,41 @@ services:
       # The restic stack includes this host path explicitly.
       - /data/hermes-backup:/opt/data/backups
 
+  # Hermes Workspace is a separate web UI. It connects to the existing Hermes
+  # gateway/dashboard and does not start a second Hermes Agent runtime.
+  hermes-workspace:
+    # Source: https://github.com/outsourc-e/hermes-workspace
+    # Immutable digest for the image published from commit c631425.
+    image: ghcr.io/outsourc-e/hermes-workspace:latest@sha256:1ec05339750da7caaf1cd0183c8c3b188856918b377407b4ac1dafca67e42d88
+    container_name: hermes-workspace
+    depends_on:
+      - hermes
+    restart: unless-stopped
+    environment:
+      # Share the Hermes home so profiles, config, memory, and skills are
+      # visible; canonical sessions are accessed through the APIs above.
+      HERMES_HOME: "/home/workspace/.hermes"
+      # Keep the file browser scoped to an explicit persistent directory.
+      HERMES_WORKSPACE_DIR: "/workspace"
+      # Reach the existing services over the hermes Compose network.
+      HERMES_API_URL: "http://hermes:8642"
+      HERMES_DASHBOARD_URL: "http://hermes:9119"
+      # Set API_SERVER_KEY in the Portainer stack environment when the gateway
+      # API is authenticated; do not commit its value here.
+      HERMES_API_TOKEN: "${API_SERVER_KEY:-}"
+      # The Workspace container binds 0.0.0.0 internally and requires its own
+      # password even though the host publish below is loopback-only.
+      HERMES_PASSWORD: "${HERMES_WORKSPACE_PASSWORD:?HERMES_WORKSPACE_PASSWORD must be set}"
+      # Use 1 behind the existing HTTPS tunnel; set 0 for direct plain HTTP.
+      COOKIE_SECURE: "${HERMES_WORKSPACE_COOKIE_SECURE:-1}"
+    ports:
+      # Keep the high-privilege UI off the public interface; route it through
+      # the existing host tunnel/reverse proxy.
+      - "127.0.0.1:${HERMES_WORKSPACE_PORT:-3000}:3000"
+    volumes:
+      - /data/hermes:/home/workspace/.hermes
+      - ${HERMES_WORKSPACE_DIR:-/data/hermes/workspace}:/workspace
+
   hindsight:
     image: ghcr.io/vectorize-io/hindsight:0.9.2
     container_name: hindsight


### PR DESCRIPTION
## Summary

- Add `hermes-workspace` as a sidecar service in the existing Portainer `hermes` stack.
- Connect it to the existing Hermes gateway and dashboard over the Compose network.
- Share `/data/hermes` for Hermes configuration, profiles, memory, skills, and API-backed session access.
- Keep the Workspace UI loopback-only on host port 3000 and require a separate Workspace password.
- Pin the Workspace image to the immutable multi-architecture digest published from upstream commit `c631425`.

## Research: what is shared?

This is an additional UI service, not a second Hermes Agent runtime in this stack. The container is a Node.js web application; the Hermes gateway remains the service that executes agent turns and uses the configured providers/models.

The state boundaries are intentionally not described as fully unified:

- **Profiles:** sharing `HERMES_HOME` makes the existing profile directories/configuration visible. The current Workspace profile screen is filesystem-backed for colocated deployments; activating a profile writes `active_profile` and warns that the Hermes gateway must be restarted. This is not proof that an already-running gateway chat is switched live.
- **Sessions:** when the dashboard APIs are available, Workspace lists/reads/updates the canonical Hermes sessions through `/api/sessions`. Its portable fallback also has a separate local `.runtime/local-sessions.json` store; those sessions are not the existing Hermes session database and are not persisted by this PR.
- **Projects:** native Hermes Projects are per-profile `projects.db` records. The current Workspace source has no native Projects API; its `/workspace` mount and Swarm/task project concepts are separate. Mounting the Hermes home therefore does not automatically import Desktop Project metadata.
- **Models/config:** chat is sent to the existing Hermes gateway, so the active agent/provider configuration remains authoritative. Workspace can also support generic OpenAI-compatible backends, but this deployment points it at Hermes.

The current stack protects the Hermes dashboard with basic authentication. Workspace currently discovers the dashboard's ephemeral session token rather than accepting dashboard basic-auth credentials, so dashboard-backed panes must be verified after deployment; this PR does not claim complete session/profile/project parity.

## Required stack variables

- `HERMES_WORKSPACE_PASSWORD` — required; set a distinct strong secret in Portainer.
- `HERMES_WORKSPACE_COOKIE_SECURE` — defaults to `1` for the existing HTTPS tunnel; set to `0` only for direct plain-HTTP access.
- `HERMES_WORKSPACE_DIR` — optional host path for the scoped `/workspace` mount; defaults to `/data/hermes/workspace`.
- `HERMES_WORKSPACE_PORT` — optional host port; defaults to `3000`.
- `API_SERVER_KEY` — set this stack variable to the existing gateway API key when API authentication is enabled; the value is passed to Workspace via `HERMES_API_TOKEN` and is not committed.

The existing Hermes Agent image remains unchanged by this PR.

## Verification

- YAML parsed with PyYAML and service-specific semantic assertions.
- `git diff --check` passed.
- Workspace image manifest resolved from GHCR; the pinned digest is multi-architecture and its OCI revision is `c631425d8baa933f8c61d8447040f4ec8b5f571c`.
- Portainer read-only discovery confirmed stack `hermes` is running and host port 3000 is unused.
- No live Portainer redeploy was performed.

## Sources

- [Hermes Workspace README](https://github.com/outsourc-e/hermes-workspace/blob/c631425d8baa933f8c61d8447040f4ec8b5f571c/README.md)
- [Hermes Workspace Dockerfile](https://github.com/outsourc-e/hermes-workspace/blob/c631425d8baa933f8c61d8447040f4ec8b5f571c/Dockerfile)
- [Workspace session API route](https://github.com/outsourc-e/hermes-workspace/blob/c631425d8baa933f8c61d8447040f4ec8b5f571c/src/routes/api/sessions.ts)
- [Workspace gateway capability detection](https://github.com/outsourc-e/hermes-workspace/blob/c631425d8baa933f8c61d8447040f4ec8b5f571c/src/server/gateway-capabilities.ts)
- [Workspace profile implementation](https://github.com/outsourc-e/hermes-workspace/blob/c631425d8baa933f8c61d8447040f4ec8b5f571c/src/server/profiles-browser.ts)
- [Hermes Agent API Server docs](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/api-server.md)
- [Hermes Agent profiles docs](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/profiles.md)
- [Hermes Agent sessions docs](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/sessions.md)
- [Hermes Agent Projects implementation](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/projects_db.py)
