### PR TITLE
feat: add Mission Control Portainer stack

### DIFF
--- a/portainer/mission-control.yaml
+++ b/portainer/mission-control.yaml
@@ -1,0 +1,62 @@
+# Mission Control — self-hosted control plane for AI agents.
+#
+# This stack runs without an OpenClaw gateway and uses the existing Codex CLI
+# OAuth home shared with Hindsight. The Codex directory is intentionally
+# read/write: Codex may refresh OAuth state and writes session history there.
+# Keep both host paths private and do not copy their contents into Git.
+services:
+  mission-control:
+    image: ghcr.io/builderz-labs/mission-control:2.3.0
+    container_name: mission-control
+    user: "1000:1000"
+    init: true
+    restart: unless-stopped
+    ports:
+      - "${MISSION_CONTROL_PORT:-3000}:3000"
+    environment:
+      PORT: "3000"
+      # Keep the CLI home inside the writable data bind mount. This gives the
+      # non-root process a writable npm cache and lets Codex use ~/.codex.
+      HOME: /app/.data
+      CODEX_HOME: /app/.data/.codex
+      PATH: /app/.data/.npm-global/bin:/app/.data/.local/bin:/app/.data/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      MISSION_CONTROL_DATA_DIR: /app/.data
+      MC_ALLOWED_HOSTS: "${MC_ALLOWED_HOSTS:-localhost,127.0.0.1}"
+      MC_COOKIE_SAMESITE: "${MC_COOKIE_SAMESITE:-strict}"
+      # Allow the built-in, reviewed runtime installer to install Codex CLI.
+      # The version is pinned so the installer does not resolve a moving tag.
+      MC_ENABLE_RUNTIME_INSTALLS: "1"
+      MC_CODEX_VERSION: "0.151.0"
+      # This stack has no OpenClaw gateway; core Mission Control features remain
+      # available, while gateway-backed live messaging is intentionally absent.
+      NEXT_PUBLIC_GATEWAY_OPTIONAL: "true"
+    volumes:
+      # Persistent SQLite database, generated credentials, and runtime-installed
+      # CLI files. /data is included in the host restic backup set.
+      - /data/mission-control:/app/.data
+      # Existing Codex subscription/OAuth state from the Hindsight stack. If it
+      # is empty, install Codex from Mission Control settings, then run
+      # `codex auth` in the container to complete the subscription login.
+      - /data/hindsight/codex:/app/.data/.codex
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=128m
+      - /app/.next/cache:rw,uid=1000,gid=1000,mode=1770,size=128m
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2.0"
+          pids: 256
+    healthcheck:
+      test: ["CMD", "node", "/app/healthcheck.js"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s


### PR DESCRIPTION
## Summary
- Add `portainer/mission-control.yaml` as a standalone Portainer GitOps stack.
- Pin Mission Control to `ghcr.io/builderz-labs/mission-control:2.3.0`.
- Persist SQLite/runtime state under `/data/mission-control`.
- Reuse the existing Hindsight Codex OAuth home at `/data/hindsight/codex`, with a pinned `@openai/codex` version and writable install path.

## Deployment notes
- Set `MC_ALLOWED_HOSTS` in Portainer before remote access; the default only permits localhost.
- The stack intentionally has no OpenClaw gateway.
- If the shared Codex OAuth directory is empty, install Codex from Mission Control settings and run `codex auth` in the container.
- No live deployment or existing stack was changed.

## Validation
- PyYAML parse and structural assertions passed.
- `git diff --check` passed.
- Published GHCR manifest for `2.3.0` verified as multi-architecture.
- `docker compose config` was not run because this host has no Compose plugin or active Docker daemon.
